### PR TITLE
Implement retry mechanism on rate limit

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -34508,7 +34508,7 @@ function error(message, properties = {}) {
  * @param properties optional properties to add to the annotation.
  */
 function warning(message, properties = {}) {
-    issueCommand('warning', toCommandProperties(properties), message instanceof Error ? message.toString() : message);
+    command_issueCommand('warning', utils_toCommandProperties(properties), message instanceof Error ? message.toString() : message);
 }
 /**
  * Adds a notice issue
@@ -38958,7 +38958,35 @@ function getOctokitOptions(token, options) {
     return opts;
 }
 //# sourceMappingURL=utils.js.map
+;// CONCATENATED MODULE: ./src/retry.ts
+
+const INITIAL_RETRY_DELAY_MS = 5000;
+const MAX_TOTAL_RETRY_DELAY_MS = 300000;
+async function retryWithBackoff(fn, isRetryable) {
+    let totalDelayMs = 0;
+    let attempt = 0;
+    while (true) {
+        try {
+            return await fn();
+        }
+        catch (error) {
+            if (!isRetryable(error)) {
+                throw error;
+            }
+            const delayMs = INITIAL_RETRY_DELAY_MS * Math.pow(2, attempt);
+            totalDelayMs += delayMs;
+            if (totalDelayMs > MAX_TOTAL_RETRY_DELAY_MS) {
+                throw new Error(`Request failed after retrying for over ${MAX_TOTAL_RETRY_DELAY_MS / 1000} seconds. Original error: ${error.message}`);
+            }
+            warning(`Retryable error encountered. Retrying in ${delayMs / 1000} seconds... (attempt ${attempt + 1})`);
+            await new Promise((resolve) => setTimeout(resolve, delayMs));
+            attempt++;
+        }
+    }
+}
+
 ;// CONCATENATED MODULE: ./src/github_helper.ts
+
 
 
 function getOctokit(auth_token) {
@@ -39007,9 +39035,14 @@ async function getReleaseSha256sum(release) {
     const sha256 = match.value[1];
     return sha256;
 }
+async function retryOnRateLimit(fn) {
+    return retryWithBackoff(fn, (error) => {
+        return error?.status === 403 && error?.message?.includes("rate limit");
+    });
+}
 async function getReleaseInfo(owner, repo, version, auth_token) {
     const octokit = getOctokit(auth_token);
-    const release = await getRelease(octokit, owner, repo, version);
+    const release = await retryOnRateLimit(() => getRelease(octokit, owner, repo, version));
     const url = await getReleaseDownloadUrl(release);
     const sha256sum = await getReleaseSha256sum(release);
     return [url, sha256sum];
@@ -39821,9 +39854,13 @@ function _unique(values) {
 
 
 
+
 async function downloadWithExtension(url) {
     const extension = external_path_namespaceObject.extname(url);
-    let assetPath = await downloadTool(url);
+    let assetPath = await retryWithBackoff(() => downloadTool(url), (error) => {
+        const status = error?.statusCode ?? error?.status;
+        return typeof status === "number" && status >= 500;
+    });
     if (external_path_namespaceObject.extname(assetPath) !== extension) {
         external_fs_namespaceObject.renameSync(assetPath, assetPath + extension);
         return assetPath + extension;

--- a/src/github_helper.test.ts
+++ b/src/github_helper.test.ts
@@ -1,4 +1,185 @@
+import {
+  jest,
+  describe,
+  test,
+  expect,
+  beforeEach,
+  afterEach,
+} from "@jest/globals";
+import { retryWithBackoff } from "./retry.js";
 import * as github_helper from "./github_helper.js";
+
+function createRateLimitError(): Error & { status: number } {
+  const error: any = new Error(
+    "API rate limit exceeded for 1.2.3.4. (But here's the good news: Authenticated requests get a higher rate limit.)",
+  );
+  error.status = 403;
+  return error;
+}
+
+function createServerError(statusCode: number): Error & { statusCode: number } {
+  const error: any = new Error(`HTTP ${statusCode}: Internal Server Error`);
+  error.statusCode = statusCode;
+  return error;
+}
+
+describe("retryWithBackoff", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  test("returns result immediately on success", async () => {
+    const result = await retryWithBackoff(
+      async () => "ok",
+      () => true,
+    );
+    expect(result).toBe("ok");
+  });
+
+  test("retries on retryable error and succeeds", async () => {
+    let calls = 0;
+    const fn = jest.fn(async () => {
+      calls++;
+      if (calls <= 1) throw createRateLimitError();
+      return "ok";
+    });
+
+    const promise = retryWithBackoff(fn, () => true);
+    await jest.advanceTimersByTimeAsync(5000);
+    const result = await promise;
+
+    expect(result).toBe("ok");
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  test("retries multiple times with exponential backoff", async () => {
+    let calls = 0;
+    const fn = jest.fn(async () => {
+      calls++;
+      if (calls <= 3) throw createRateLimitError();
+      return "ok";
+    });
+
+    const promise = retryWithBackoff(fn, () => true);
+    await jest.advanceTimersByTimeAsync(5000);
+    await jest.advanceTimersByTimeAsync(10000);
+    await jest.advanceTimersByTimeAsync(20000);
+    const result = await promise;
+
+    expect(result).toBe("ok");
+    expect(fn).toHaveBeenCalledTimes(4);
+  });
+
+  test("does not retry when predicate returns false", async () => {
+    const error: any = new Error("Not Found");
+    error.status = 404;
+
+    const fn = jest.fn(async () => {
+      throw error;
+    });
+
+    await expect(retryWithBackoff(fn, (e) => e.status === 403)).rejects.toThrow(
+      "Not Found",
+    );
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  test("gives up after max total delay exceeded", async () => {
+    const fn = jest.fn(async () => {
+      throw createRateLimitError();
+    });
+
+    const promise = retryWithBackoff(fn, () => true);
+    promise.catch(() => {});
+
+    await jest.advanceTimersByTimeAsync(5000);
+    await jest.advanceTimersByTimeAsync(10000);
+    await jest.advanceTimersByTimeAsync(20000);
+    await jest.advanceTimersByTimeAsync(40000);
+    await jest.advanceTimersByTimeAsync(80000);
+
+    await expect(promise).rejects.toThrow("Request failed after retrying");
+    expect(fn).toHaveBeenCalledTimes(6);
+  });
+
+  test("retries on server errors (5xx)", async () => {
+    let calls = 0;
+    const fn = jest.fn(async () => {
+      calls++;
+      if (calls <= 2) throw createServerError(503);
+      return "ok";
+    });
+
+    const promise = retryWithBackoff(fn, (error: any) => {
+      const status = error?.statusCode ?? error?.status;
+      return typeof status === "number" && status >= 500;
+    });
+    await jest.advanceTimersByTimeAsync(5000);
+    await jest.advanceTimersByTimeAsync(10000);
+    const result = await promise;
+
+    expect(result).toBe("ok");
+    expect(fn).toHaveBeenCalledTimes(3);
+  });
+});
+
+describe("retryOnRateLimit (github_helper)", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  test("retries on rate limit 403 and succeeds", async () => {
+    let calls = 0;
+    const fn = jest.fn(async () => {
+      calls++;
+      if (calls <= 1) throw createRateLimitError();
+      return "ok";
+    });
+
+    const promise = github_helper.retryOnRateLimit(fn);
+    await jest.advanceTimersByTimeAsync(5000);
+    const result = await promise;
+
+    expect(result).toBe("ok");
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  test("does not retry on non-rate-limit 403", async () => {
+    const error: any = new Error("Forbidden");
+    error.status = 403;
+
+    const fn = jest.fn(async () => {
+      throw error;
+    });
+
+    await expect(github_helper.retryOnRateLimit(fn)).rejects.toThrow(
+      "Forbidden",
+    );
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  test("does not retry on non-403 errors", async () => {
+    const error: any = new Error("Not Found");
+    error.status = 404;
+
+    const fn = jest.fn(async () => {
+      throw error;
+    });
+
+    await expect(github_helper.retryOnRateLimit(fn)).rejects.toThrow(
+      "Not Found",
+    );
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+});
 
 test("Oktokit getter, no token", () => {
   const octokit = github_helper.getOctokit();

--- a/src/github_helper.ts
+++ b/src/github_helper.ts
@@ -1,5 +1,6 @@
 import { Octokit } from "@octokit/rest";
 import { getOctokitOptions } from "@actions/github/lib/utils";
+import { retryWithBackoff } from "./retry.js";
 
 export function getOctokit(auth_token?: string) {
   let options = {};
@@ -70,6 +71,12 @@ async function getReleaseSha256sum(release: any): Promise<string> {
   return sha256;
 }
 
+export async function retryOnRateLimit<T>(fn: () => Promise<T>): Promise<T> {
+  return retryWithBackoff(fn, (error: any) => {
+    return error?.status === 403 && error?.message?.includes("rate limit");
+  });
+}
+
 export async function getReleaseInfo(
   owner: string,
   repo: string,
@@ -77,7 +84,9 @@ export async function getReleaseInfo(
   auth_token?: string,
 ): Promise<[string, string]> {
   const octokit = getOctokit(auth_token);
-  const release = await getRelease(octokit, owner, repo, version);
+  const release = await retryOnRateLimit(() =>
+    getRelease(octokit, owner, repo, version),
+  );
   const url = await getReleaseDownloadUrl(release);
   const sha256sum = await getReleaseSha256sum(release);
   return [url, sha256sum];

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -3,10 +3,17 @@ import * as core from "@actions/core";
 import * as path from "path";
 import * as fs from "fs";
 import * as crypto from "crypto";
+import { retryWithBackoff } from "./retry.js";
 
 async function downloadWithExtension(url: string): Promise<string> {
   const extension = path.extname(url);
-  let assetPath = await tc.downloadTool(url);
+  let assetPath = await retryWithBackoff(
+    () => tc.downloadTool(url),
+    (error: any) => {
+      const status = error?.statusCode ?? error?.status;
+      return typeof status === "number" && status >= 500;
+    },
+  );
   if (path.extname(assetPath) !== extension) {
     fs.renameSync(assetPath, assetPath + extension);
     return assetPath + extension;

--- a/src/retry.ts
+++ b/src/retry.ts
@@ -1,0 +1,37 @@
+import { warning } from "@actions/core";
+
+export const INITIAL_RETRY_DELAY_MS = 5000;
+export const MAX_TOTAL_RETRY_DELAY_MS = 300000;
+
+export async function retryWithBackoff<T>(
+  fn: () => Promise<T>,
+  isRetryable: (error: any) => boolean,
+): Promise<T> {
+  let totalDelayMs = 0;
+  let attempt = 0;
+
+  while (true) {
+    try {
+      return await fn();
+    } catch (error: any) {
+      if (!isRetryable(error)) {
+        throw error;
+      }
+
+      const delayMs = INITIAL_RETRY_DELAY_MS * Math.pow(2, attempt);
+      totalDelayMs += delayMs;
+
+      if (totalDelayMs > MAX_TOTAL_RETRY_DELAY_MS) {
+        throw new Error(
+          `Request failed after retrying for over ${MAX_TOTAL_RETRY_DELAY_MS / 1000} seconds. Original error: ${error.message}`,
+        );
+      }
+
+      warning(
+        `Retryable error encountered. Retrying in ${delayMs / 1000} seconds... (attempt ${attempt + 1})`,
+      );
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+      attempt++;
+    }
+  }
+}


### PR DESCRIPTION
Retry mechanism implementation for fetching Ghidra (and any other requests)
Will retry up to 2 minutes 36seconds*,  starting from a 5 second wait with exponential backoff.

Adds tests to verify behavior
Resolves https://github.com/antoniovazquezblanco/setup-ghidra/issues/117